### PR TITLE
⚗ Add scroll to bottom of chat on submit and back

### DIFF
--- a/src/views/Response.jsx
+++ b/src/views/Response.jsx
@@ -155,6 +155,7 @@ export const Response = ({ location }) => {
       localStorage.setItem(`cur:${hash.current}`, cursor + 1);
     }
     setCursor(cursor + 1);
+    scrollResponse();
   };
 
   const handleKeypress = (e) => {
@@ -166,7 +167,13 @@ export const Response = ({ location }) => {
   const handleBack = () => {
     setCurrentResponse(responses[cursor - 1]);
     setCursor(cursor - 1);
+    scrollResponse();
   };
+
+  const scrollResponse = () => {
+    const feed = document.querySelector('.survey__feed');
+    feed.scroll({top: feed.scrollHeight, behavior: 'smooth'});
+  }
 
   return (
     <div className="survey d-flex py-md-4">


### PR DESCRIPTION
- Adds a method to Response.jsx called `scrollResponse()`
- Calls `scrollResponse();` at bottom of `handleSubmit()` and `handleBack()`
- Utilizes native `<element>.scroll()` functionality

TODO: Evaluate if `behavior: 'smooth'` is responsive enough

/cc: @cvasquez 
