### PR TITLE
Fix blank download image when scrolled

### DIFF
--- a/src/views/Responses.jsx
+++ b/src/views/Responses.jsx
@@ -53,6 +53,10 @@ export const Responses = () => {
   const share = async (id, name) => {
     const canvas = await html2canvas(
       document.getElementById(id).getElementsByClassName('card-body')[0],
+      {
+        scrollX: 0,
+        scrollY: -window.scrollY,
+      },
     );
     canvas.style.display = 'none';
     document.body.appendChild(canvas);


### PR DESCRIPTION
🐛 Fix issue where response download image would be blanked when response had to be scrolled to.